### PR TITLE
Fix test for symlink vs. actual file.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
   sha256: 88f29bec81880844da2eee13f1cdc51e1ccd8b4c60af6df633577810b30f80d0  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [osx]
 
 outputs:
@@ -50,8 +50,8 @@ outputs:
       commands:
         - test -L $PREFIX/lib/libcublas.so.{{ version }}                                          # [linux]
         - test -L $PREFIX/lib/libcublas.so.{{ version.split(".")[0] }}                            # [linux]
-        - test -L $PREFIX/targets/{{ target_name }}/lib/libcublas.so.{{ version }}                # [linux]
-        - test -f $PREFIX/targets/{{ target_name }}/lib/libcublas.so.{{ version.split(".")[0] }}  # [linux]
+        - test -L $PREFIX/targets/{{ target_name }}/lib/libcublas.so.{{ version.split(".")[0] }}  # [linux]
+        - test -f $PREFIX/targets/{{ target_name }}/lib/libcublas.so.{{ version }}                # [linux]
         - if not exist %LIBRARY_BIN%\cublas64_{{ version.split(".")[0] }}.dll exit 1              # [win]
         - if not exist %LIBRARY_BIN%\cublasLt64_{{ version.split(".")[0] }}.dll exit 1            # [win]
         - if not exist %LIBRARY_BIN%\nvblas64_{{ version.split(".")[0] }}.dll exit 1              # [win]


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

While reviewing https://github.com/conda-forge/staged-recipes/pull/21902, I noticed that the tests for libcublas on Linux were checking if `libcublas.so.12` is a file and `libcublas.so.12.0.1.189` is a symlink. However, that's backwards. `libcublas.so.12` should be a symlink pointing to `libcublas.so.12.0.1.189`. I'm not sure how this passed CI before, because `test -L $PREFIX/targets/{{ target_name }}/lib/libcublas.so.{{ version }}` should not pass from what I can tell.