### PR TITLE
Add cuda-nvrtc dependency for dlopen bug.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -146,10 +146,10 @@ outputs:
         - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
-         # In 12.0/12.1 libcublas runtime will try to dlopen nvrtc due to a bug
-         # so it must be listed as a runtime dependency.
-         # See https://github.com/conda-forge/libcublas-feedstock/issues/9
-         - cuda-nvrtc
+        # In 12.0/12.1 libcublas runtime will try to dlopen nvrtc due to a bug
+        # so it must be listed as a runtime dependency.
+        # See https://github.com/conda-forge/libcublas-feedstock/issues/9
+        - cuda-nvrtc
       run_constrained:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -146,6 +146,10 @@ outputs:
         - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
+         # In 12.0/12.1 libcublas runtime will try to dlopen nvrtc due to a bug
+         # so it must be listed as a runtime dependency.
+         # See https://github.com/conda-forge/libcublas-feedstock/issues/9
+         - cuda-nvrtc
       run_constrained:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
   sha256: 88f29bec81880844da2eee13f1cdc51e1ccd8b4c60af6df633577810b30f80d0  # [win]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [osx]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,10 @@ outputs:
          - cuda-version {{ cuda_version }}
       run:
          - {{ pin_compatible("cuda-version", max_pin="x.x") }}
+         # In 12.0/12.1 libcublas runtime will try to dlopen nvrtc due to a bug
+         # so it must be listed as a runtime dependency.
+         # See https://github.com/conda-forge/libcublas-feedstock/issues/9
+         - cuda-nvrtc
       run_constrained:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     # Tests are defined at the top level, due to package/output name conflicts.


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

In 12.0/12.1 libcublas runtime will try to dlopen nvrtc due to a bug. This adds a dependency to avoid that bug. Closes #9.